### PR TITLE
Remove .zuul.yaml file

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,7 +1,0 @@
-- project:
-    check:
-      jobs:
-        - tox-linters
-    gate:
-      jobs:
-        - tox-linters


### PR DESCRIPTION
We are in the process of moving from sf.io to zuul.ansible.com. We can
revert once the migration is finished.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>