### PR TITLE
Add code to generate collections version strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+*.egg
+*.egg-info
+*.pyc
 .tox

--- a/ansible_releases/cmd/generate_ansible_collection.py
+++ b/ansible_releases/cmd/generate_ansible_collection.py
@@ -1,0 +1,37 @@
+# Copyright 2019 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import pbr.version
+
+from ruamel.yaml import YAML
+
+
+def generate_version_info():
+    version_info = pbr.version.VersionInfo('random')
+    semantic_version = version_info.semantic_version()
+    release_string = semantic_version._long_version('-')
+
+    yaml = YAML()
+    yaml.explicit_start = True
+    yaml.indent(sequence=4, offset=2)
+
+    config = yaml.load(open('galaxy.yml'))
+    config['version'] = release_string
+
+    with open('galaxy.yml', 'w') as fp:
+        yaml.dump(config, fp)
+
+
+def main():
+    generate_version_info()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+ruamel.yaml
+pbr
 python-twitter

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,32 @@
+[metadata]
+name = ansible_releases
+summary = Ansible Releases
+description-file =
+    README.rst
+author = Paul Belanger
+author-email = pabelanger@redhat.com
+home-page = https://www.ansible.com
+classifier =
+    Intended Audience :: Information Technology
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: Apache Software License
+    Operating System :: POSIX :: Linux
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+
+[files]
+packages = ansible_releases
+
+[entry_points]
+console_scripts =
+    generate-ansible-collection = ansible_releases.cmd.generate_ansible_collection:main
+
+[build_sphinx]
+source-dir = doc/source
+build-dir = doc/build
+all_files = 1
+builders = html
+warning-is-error = 1
+
+[upload_sphinx]
+upload-dir = doc/build/html

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# Copyright (c) 2013 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# THIS FILE IS MANAGED BY THE GLOBAL REQUIREMENTS REPO - DO NOT EDIT
+import setuptools
+
+setuptools.setup(
+    setup_requires=['pbr'],
+    pbr=True)

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ skipsdist = True
 envlist = linters
 
 [testenv]
+basepython = python3
+usedevelop = True
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
@@ -12,6 +14,9 @@ deps = -r{toxinidir}/requirements.txt
 basepython = python3
 commands =
   flake8 {posargs}
+
+[testenv:generate_collection_version]
+commands = generate-ansible-collection
 
 [testenv:venv]
 commands = {posargs}


### PR DESCRIPTION
This starts the process to create release scripts to be used by Zuul.
We'll leverage pbr here to generate version numbers both from git commit
and git tags.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>