### PR TITLE
Require ansible>2.9

### DIFF
--- a/ansible_releases/cmd/generate_ansible_collection.py
+++ b/ansible_releases/cmd/generate_ansible_collection.py
@@ -31,6 +31,7 @@ def generate_version_info():
 
     with open('galaxy.yml', 'w') as fp:
         yaml.dump(config, fp)
+    print(f"{config['namespace']}-{config['name']}-{config['version']}.tar.gz")
 
 
 def main():


### PR DESCRIPTION
This is the first release to support ansible-galaxy collections.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>