### PR TITLE
Don't use galaxy-importer 0.2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansible
-galaxy-importer
+galaxy-importer!=0.2.6
 ruamel.yaml
 pbr
 python-twitter


### PR DESCRIPTION
This is a broke release with the following error:

  ModuleNotFoundError: No module named 'galaxy_importer.ansible_test.builders'

Signed-off-by: Paul Belanger <pabelanger@redhat.com>