### PR TITLE
Move more requirements into tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,10 +23,14 @@ whitelist_externals =
 commands = bash -c '{toxinidir}/tools/validate-collection.sh {posargs}'
 
 [testenv:generate_collection_version]
+deps =
+  pbr
+  ruamel.yaml
 commands = generate-ansible-collection
 
 [testenv:generate_poetry_version]
 deps =
+  pbr
   poetry
 commands = generate-poetry-version
 


### PR DESCRIPTION
This prepares to drop the requirements.txt files

Signed-off-by: Paul Belanger <pabelanger@redhat.com>