### PR TITLE
Revert "Use return code from galaxy-importer"

### DIFF
--- a/tools/validate-collection.sh
+++ b/tools/validate-collection.sh
@@ -18,4 +18,7 @@ set -e
 ARTIFACT=$1
 
 # galaxy_importer.main does not return non-zero error code on error
-python -m galaxy_importer.main $ARTIFACT
+output=$(python -m galaxy_importer.main $ARTIFACT)
+if echo $output | grep ERROR: ; then
+    exit 1
+fi


### PR DESCRIPTION
This reverts commit f2a4f3c0f7922549c610744b4007e5924c254c0d.

We should always look for ERRORs in galaxy-importer, to ensure we always
fix issues.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>