### PR TITLE
Fix Zuul by depending on ansible-core instead of ansible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible
+ansible-core
 galaxy-importer
 ruamel.yaml
 pbr


### PR DESCRIPTION
This is needed because galaxy-importer now depends on ansible-core (https://github.com/ansible/galaxy-importer/commit/98933547831922c45243f39d85eefe150b55fc36), and since Ansible 4.0.0 has not yet been released.
