### PR TITLE
Replace python-twitter with tweepy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ruamel.yaml
 pbr
-python-twitter
+tweepy

--- a/tools/twitter-announcement.py
+++ b/tools/twitter-announcement.py
@@ -26,7 +26,7 @@ import argparse
 import configparser
 import os
 
-import twitter
+import tweepy
 
 
 class Tweet():
@@ -35,14 +35,13 @@ class Tweet():
         self.consumer_secret = config.get('twitter', 'consumer_secret')
         self.access_token_key = config.get('twitter', 'access_token_key')
         self.access_token_secret = config.get('twitter', 'access_token_secret')
-        self.api = twitter.Api(
-            consumer_key=self.consumer_key,
-            consumer_secret=self.consumer_secret,
-            access_token_key=self.access_token_key,
-            access_token_secret=self.access_token_secret)
+
+        auth = tweepy.OAuthHandler(self.consumer_key, self.consumer_secret)
+        auth.set_access_token(self.access_token_key, self.access_token_secret)
+        self.api = tweepy.Api(auth)
 
     def send(self, msg):
-        self.api.PostUpdates(msg, continuation=u'\u2026')
+        self.api.update_status(status=msg)
 
 
 def main():


### PR DESCRIPTION
What this does not handle at present is tweets that go over the 280 character limit. I don't know if we ever get anywhere near that limit, but we were using `PostUpdates` instead of `PostUpdate` which leads me to believe it could be a potential concern.