### PR TITLE
Where the version in galaxy.yml is higher than the last tagged versio…

### DIFF
--- a/ansible_releases/cmd/generate_ansible_collection.py
+++ b/ansible_releases/cmd/generate_ansible_collection.py
@@ -20,13 +20,22 @@ from ruamel.yaml import YAML
 def generate_version_info():
     version_info = pbr.version.VersionInfo('random')
     semantic_version = version_info.semantic_version()
-    release_string = semantic_version._long_version('-')
 
     yaml = YAML()
     yaml.explicit_start = True
     yaml.indent(sequence=4, offset=2)
 
     config = yaml.load(open('galaxy.yml'))
+
+    try:
+        galaxy_version = str(config['version']).replace("-", ".")
+        galaxy_version = pbr.version.SemanticVersion.from_pip_string(
+            galaxy_version)
+    except (ValueError, TypeError):
+        galaxy_version = semantic_version
+
+    release_version = max(galaxy_version, semantic_version)
+    release_string = release_version._long_version('-')
     config['version'] = release_string
 
     with open('galaxy.yml', 'w') as fp:

--- a/ansible_releases/cmd/generate_ansible_collection.py
+++ b/ansible_releases/cmd/generate_ansible_collection.py
@@ -28,7 +28,7 @@ def generate_version_info():
     config = yaml.load(open('galaxy.yml'))
 
     try:
-        galaxy_version = str(config['version']).replace("-", ".")
+        galaxy_version = str(config.get('version')).replace("-", ".")
         galaxy_version = pbr.version.SemanticVersion.from_pip_string(
             galaxy_version)
     except (ValueError, TypeError):


### PR DESCRIPTION
During the major release process galaxy.yml is updated in a PR, but the oldest tag will still be on the previous major release.

The original implementation forces the use of the last tag as a base version id, which means that version related sanity tests (such as expired deprecations) are effectively skipped, and as soon as the release is tagged CI will break due to the expired deprecations.

For example: now that 4.0.0 has *been* released we're seeing [deprecation failures](https://c08f2a04584e874a6786-5004ca543dc942bd5f2cccee3d00dc01.ssl.cf5.rackcdn.com/1254/d178b3504df19c1f057583d4f15a8c9d30b962ea/check/ansible-test-sanity-docker-stable-2.12/31b3a29/job-output.txt)

```
2022-06-24 08:02:54.519146 | controller | ERROR: Found 4 pylint issue(s) which need to be resolved:
2022-06-24 08:02:54.519321 | controller | ERROR: plugins/modules/iam_server_certificate.py:321:8: collection-deprecated-version: Deprecated version ('4.0.0') found in call to Display.deprecated or AnsibleModule.deprecate
2022-06-24 08:02:54.519393 | controller | ERROR: plugins/modules/iam_server_certificate.py:328:8: collection-deprecated-version: Deprecated version ('4.0.0') found in call to Display.deprecated or AnsibleModule.deprecate
2022-06-24 08:02:54.519463 | controller | ERROR: plugins/modules/iam_server_certificate.py:335:8: collection-deprecated-version: Deprecated version ('4.0.0') found in call to Display.deprecated or AnsibleModule.deprecate
2022-06-24 08:02:54.519526 | controller | ERROR: plugins/modules/iam_server_certificate.py:408:8: collection-deprecated-version: Deprecated version ('4.0.0') found in call to Display.deprecated or AnsibleModule.deprecate
...
2022-06-24 08:03:00.850531 | controller | ERROR: Found 2 runtime-metadata issue(s) which need to be resolved:
2022-06-24 08:03:00.850629 | controller | ERROR: meta/runtime.yml:0:0: The deprecation removal_version ('4.0.0') must be after the current version (SemanticVersion('4.0.1-dev1')) for dictionary value @ data['plugin_routing']['modules']['iam_cert']['deprecation']['removal_version']. Got '4.0.0'
2022-06-24 08:03:00.850695 | controller | ERROR: meta/runtime.yml:0:0: The deprecation removal_version ('4.0.0') must be after the current version (SemanticVersion('4.0.1-dev1')) for dictionary value @ data['plugin_routing']['modules']['rds_snapshot']['deprecation']['removal_version']. Got '4.0.0'
```

Which should have been caught back in January when we updated galaxy.yml in the main branch: https://github.com/ansible-collections/community.aws/pull/897