### PR TITLE
Die if the version in galaxy.yml does not agree with the git version - but only if --for-release is supplied.

### DIFF
--- a/ansible_releases/cmd/generate_ansible_collection.py
+++ b/ansible_releases/cmd/generate_ansible_collection.py
@@ -12,6 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import sys
+
 import pbr.version
 
 from ruamel.yaml import YAML
@@ -33,6 +35,12 @@ def generate_version_info():
             galaxy_version)
     except (ValueError, TypeError):
         galaxy_version = semantic_version
+
+    if '--for-release' in sys.argv and galaxy_version != semantic_version:
+        print(
+            f'ERROR: galaxy.yml version {galaxy_version} does not coincide'
+            f' with git version {semantic_version}!')
+        sys.exit(1)
 
     release_version = max(galaxy_version, semantic_version)
     release_string = release_version._long_version('-')


### PR DESCRIPTION
Sometimes during releases, it happens that the version in the git tag does not coincide with the version in galaxy.yml (when explicitly specified). This is bad since then the tag no longer refers to the actual source of the built collection (running `ansible-galaxy collection build` in the checkout will build *another* version).

This adds a check that will fail if the git and galaxy.yml versions disagree.

This check is only done when `--for-release` is supplied on the command line, to avoid problems in CI (see #22).

CC @gotmax23 @tremble