### PR TITLE
validate-collection.sh: also catch low-case Error in the output

### DIFF
--- a/tools/validate-collection.sh
+++ b/tools/validate-collection.sh
@@ -19,6 +19,6 @@ ARTIFACT=$1
 
 # galaxy_importer.main does not return non-zero error code on error
 output=$(python -m galaxy_importer.main $ARTIFACT)
-if echo $output | grep ERROR: ; then
+if echo $output | grep -i ERROR: ; then
     exit 1
 fi


### PR DESCRIPTION
Those can come from `ansible-lint`.
